### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+        args: ['--markdown-linebreak-ext=md']
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.4
     hooks:


### PR DESCRIPTION
Change args of trailing-whitespaces to preserve hard new line breaks (like double spaces) in .md files

Source:[https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#trailing-whitespace)